### PR TITLE
Add packet-sending helper namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,6 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
-- [#2](https:/github.com/muattiyah/udp-wrapper/issues/2): Expose the rest of DatagramSocket's options as a config map.
-- [#3](https:/github.com/muattiyah/udp-wrapper/issues/3): Add a new namespace, `udp-wrapper.packet`, with helper methods for sending and receiving data.
+- [#2](https://github.com/muattiyah/udp-wrapper/issues/2): Expose the rest of DatagramSocket's options as a config map.
+- [#3](https://github.com/muattiyah/udp-wrapper/issues/3): Add a new namespace, `udp-wrapper.packet`, with helper methods for sending and receiving data.
 - .gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 - [#2](https:/github.com/muattiyah/udp-wrapper/issues/2): Expose the rest of DatagramSocket's options as a config map.
+- [#3](https:/github.com/muattiyah/udp-wrapper/issues/3): Add a new namespace, `udp-wrapper.packet`, with helper methods for sending and receiving data.
 - .gitignore

--- a/src/udp_wrapper/packet.clj
+++ b/src/udp_wrapper/packet.clj
@@ -1,0 +1,36 @@
+(ns udp-wrapper.packet
+  (:require [udp-wrapper.core :as core]))
+
+(defn- wait [seconds] (if seconds (Thread/sleep (* 1000 seconds))))
+
+(defn create-packet
+  "Helper to coerce data + destination into packet"
+  [data address port]
+  (core/packet (core/get-bytes-utf8 data) (core/make-address address) port))
+
+(defn send-packet
+  "Send a constructed packet, without receiving"
+  [data socket address port & [wait-seconds]]
+  (let [packet (create-packet data address port)]
+    (core/send-message socket packet)
+    (wait wait-seconds)
+    packet))
+
+(defn send-packets
+  "Send a collection of constructed packets, without receiving"
+  [data socket address port]
+  (doall (map #(send-packet % socket address port) data)))
+
+(defn send-packet-and-receive
+  "Send a constructed packet, wait, and then recieve data back"
+  [data socket address port wait-seconds]
+  (let [packet (send-packet data socket address port)]
+    (wait wait-seconds)
+    (core/receive-message-data socket packet)))
+
+(defn send-packets-and-receive
+  "Send a collection of constructed packets, wait, and then recieve data back"
+  [data socket address port wait-seconds]
+  (let [packets (send-packets data socket address port)]
+    (wait wait-seconds)
+    (doall (map #(core/receive-message-data socket %) packets))))


### PR DESCRIPTION
I had these methods sitting elsewhere in my project, and I realized that they could live happily in udp-wrapper itself if desired. 

What do you think of the namespace name? I just picked whatever came to mind. Let me know what you want changed and I'll submit it asap. 